### PR TITLE
Add fill minefield with hints

### DIFF
--- a/models/field.go
+++ b/models/field.go
@@ -1,5 +1,34 @@
 package models
 
+import (
+	"fmt"
+	"strconv"
+)
+
+var mineString = "MINE"
+
 type Field struct {
 	Value *string `json:"value"`
+}
+
+func (f *Field) setValue(value string) {
+	f.Value = &value
+}
+
+func (f *Field) SetInitialHintValue() {
+	f.setValue("1")
+}
+
+func (f *Field) IncrementHintValue() {
+	intValue, _ := strconv.Atoi(*f.Value)
+	value := fmt.Sprintf("%v", intValue+1)
+	f.setValue(value)
+}
+
+func (f *Field) SetMine() {
+	f.setValue(mineString)
+}
+
+func (f *Field) IsMine() bool {
+	return *f.Value == mineString
 }

--- a/models/field_test.go
+++ b/models/field_test.go
@@ -1,0 +1,57 @@
+package models
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestField_IncrementHintValue(t *testing.T) {
+	value := "1"
+	field := Field{Value: &value}
+
+	field.IncrementHintValue()
+
+	assert.Equal(t, "2", *field.Value)
+}
+
+func TestField_IsMine(t *testing.T) {
+	field := Field{Value: &mineString}
+
+	field.IsMine()
+
+	assert.True(t, field.IsMine())
+}
+
+func TestField_IsMine_false(t *testing.T) {
+	value := "foo"
+	field := Field{Value: &value}
+
+	field.IsMine()
+
+	assert.False(t, field.IsMine())
+}
+
+func TestField_SetInitialHintValue(t *testing.T) {
+	field := Field{}
+
+	field.SetInitialHintValue()
+
+	assert.Equal(t, "1", *field.Value)
+}
+
+func TestField_SetMine(t *testing.T) {
+	field := Field{}
+
+	field.SetMine()
+
+	assert.Equal(t, mineString, *field.Value)
+}
+
+func TestField_setValue(t *testing.T) {
+	field := Field{}
+
+	value := "foo"
+	field.setValue(value)
+
+	assert.Equal(t, value, *field.Value)
+}

--- a/models/game.go
+++ b/models/game.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+var borderingPositions = []Position{
+	{X: 0, Y: 1}, {X: 1, Y: 1}, {X: 1, Y: 0}, {X: 1, Y: -1},
+	{X: 0, Y: -1}, {X: -1, Y: -1}, {X: -1, Y: 0}, {X: -1, Y: 1},
+}
+
 type Game struct {
 	StartedAt time.Time  `json:"startedAt"`
 	Settings  Settings   `json:"settings"`
@@ -13,17 +18,43 @@ type Game struct {
 	Status    Status     `json:"status"`
 }
 
-func fillMinefieldWithMines(minefield *[][]Field, settings *Settings) {
+func fillMinefieldWithMines(minefield *[][]Field, settings *Settings) []Position {
 	bombsCounter := settings.MinesQuantity
+
+	minesPositions := make([]Position, bombsCounter)
 
 	for ok := true; ok; ok = bombsCounter != 0 {
 		yPosition := rand.Intn(settings.Height)
 		xPosition := rand.Intn(settings.Width)
 
 		if field := &(*minefield)[yPosition][xPosition]; field.Value == nil {
-			mineString := "MINE"
-			field.Value = &mineString
+			field.SetMine()
+			minesPositions[bombsCounter-1] = Position{Y: yPosition, X: xPosition}
 			bombsCounter--
+		}
+	}
+
+	return minesPositions
+}
+
+func fillMinefieldWithHints(minefield *[][]Field, settings *Settings, minesPositions []Position) {
+	for _, position := range minesPositions {
+		for _, borderingPosition := range borderingPositions {
+			candidatePositionY := position.Y + borderingPosition.Y
+			candidatePositionX := position.X + borderingPosition.X
+
+			isCandidateInsideMinefield :=
+				candidatePositionY < settings.Height && candidatePositionY != -1 &&
+					candidatePositionX < settings.Width && candidatePositionX != -1
+
+			if isCandidateInsideMinefield {
+				field := &(*minefield)[candidatePositionY][candidatePositionX]
+				if field.Value == nil {
+					field.SetInitialHintValue()
+				} else if !field.IsMine() {
+					field.IncrementHintValue()
+				}
+			}
 		}
 	}
 }
@@ -34,7 +65,8 @@ func createMinefield(settings *Settings) *[][]Field {
 		minefield[index] = make([]Field, settings.Width)
 	}
 
-	fillMinefieldWithMines(&minefield, settings)
+	minesPositions := fillMinefieldWithMines(&minefield, settings)
+	fillMinefieldWithHints(&minefield, settings, minesPositions)
 
 	return &minefield
 }

--- a/models/game_test.go
+++ b/models/game_test.go
@@ -38,23 +38,37 @@ func TestNewGame_err(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func Test_fillMinefieldWithBombs(t *testing.T) {
-	settingsMock := &Settings{Height: 3, Width: 3, MinesQuantity: 1}
+func Test_fillMinefieldWithMines(t *testing.T) {
+	settingsMock := &Settings{Height: 3, Width: 3, MinesQuantity: 3}
 	minefield := make([][]Field, settingsMock.Height)
 	for index := range minefield {
 		minefield[index] = make([]Field, settingsMock.Width)
 	}
 
-	fillMinefieldWithMines(&minefield, settingsMock)
+	minesPositions := fillMinefieldWithMines(&minefield, settingsMock)
 
-	minesCounter := 0
-	for _, fieldLine := range minefield {
-		for _, field := range fieldLine {
-			if field.Value != nil && *field.Value == "MINE" {
-				minesCounter++
-			}
-		}
+	assert.Equal(t, settingsMock.MinesQuantity, len(minesPositions))
+}
+
+func Test_fillMinefieldWithHints(t *testing.T) {
+	settingsMock := &Settings{Height: 3, Width: 2, MinesQuantity: 2}
+	minefield := make([][]Field, settingsMock.Height)
+	for index := range minefield {
+		minefield[index] = make([]Field, settingsMock.Width)
 	}
 
-	assert.Equal(t, settingsMock.MinesQuantity, minesCounter)
+	positionOne := Position{Y: 0, X: 1}
+	positionTwo := Position{Y: 0, X: 0}
+
+	minefield[positionOne.Y][positionOne.X].SetMine()
+	minefield[positionTwo.Y][positionTwo.X].SetMine()
+
+	fillMinefieldWithHints(&minefield, settingsMock, []Position{positionOne, positionTwo})
+
+	assert.True(t, minefield[positionOne.Y][positionOne.X].IsMine())
+	assert.True(t, minefield[positionTwo.Y][positionTwo.X].IsMine())
+	assert.Equal(t, "2", *minefield[1][0].Value)
+	assert.Equal(t, "2", *minefield[1][1].Value)
+	assert.Nil(t, minefield[2][0].Value)
+	assert.Nil(t, minefield[2][1].Value)
 }

--- a/models/position.go
+++ b/models/position.go
@@ -1,0 +1,6 @@
+package models
+
+type Position struct {
+	X int
+	Y int
+}


### PR DESCRIPTION
## Summary of this modifications
<!-- What have you added, fixed or improved...  -->
**Added:**
- Fill minefield with hint function

## I've ...
- [X] run the linter
- [X] create tests and improve coverage as much as possible

## Notes for the reviewer
<!-- Anything you want to tell the reviewer to understand or challenge this pull request...  -->
For each mine iterate over the bordering positions to set the mines number.

